### PR TITLE
Fixes rows not being dropped as expected

### DIFF
--- a/qbods.py
+++ b/qbods.py
@@ -1034,7 +1034,7 @@ def q331(ownershipOrControlStatement, samplesize=100):
 
     # replaces empty strings with NaNs, then drops all rows with a NaN value
 
-    el['interestedParty'].replace('', pd.np.nan, inplace=True)
+    el['interestedParty'].replace('', np.nan, inplace=True)
 
     el.dropna(subset=['interestedParty'], inplace=True)
 

--- a/qbods.py
+++ b/qbods.py
@@ -1030,7 +1030,15 @@ def q331(ownershipOrControlStatement, samplesize=100):
     interestedParty = ipPersonList+ipEntityList
 
     el = pd.DataFrame(
-        {'subject': subject, 'interestedParty': interestedParty}).dropna()
+        {'subject': subject, 'interestedParty': interestedParty})
+
+    # replaces empty strings with NaNs, then drops all rows with a NaN value
+
+    el['interestedParty'].replace('', pd.np.nan, inplace=True)
+
+    el.dropna(subset=['interestedParty'], inplace=True)
+
+    # creates the graph, G
 
     G = nx.from_pandas_edgelist(el, 'subject', 'interestedParty')
     components = list(nx.connected_components(G))


### PR DESCRIPTION
The [UK PSC Dashboard notebook](https://deepnote.com/workspace/open-ownership-25677d4c-15b9-48a0-9053-f64d967148f5/project/UK-PSC-dashboard-2a4e8e4e-492e-48cb-891c-34b1d852dbfd/notebook/template-ef1ecaf6e91c488eb6e99c8c8497ea96) was generating an error when trying to use this q331 function. See the [troubleshooting notebook](https://deepnote.com/workspace/open-ownership-25677d4c-15b9-48a0-9053-f64d967148f5/project/UK-PSC-dashboard-troubleshooting-8665d1b0-b61b-4c7a-aeaa-f887a87db550/notebook/template-d8d12157a84d4b1f8e12ff75df8dd303) for an explanation of the problem. This is the fix for it.

(What I don't understand is why this this problem has only occurred now. The dashboard notebook has been run successfully in the past.)